### PR TITLE
Fix operation extensions are not sorted regularly

### DIFF
--- a/extension.go
+++ b/extension.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"github.com/tidwall/sjson"
@@ -134,8 +135,16 @@ func marshalExtendedJSON(dst extended) ([]byte, error) {
 
 func marshalExtendedJSONInto(data []byte, obj extended) ([]byte, error) {
 	var err error
-	for k, v := range obj.exts() {
-		data, err = sjson.SetBytes(data, k, v)
+
+	exts := obj.exts()
+	keys := make([]string, 0, len(exts))
+	for k := range exts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		data, err = sjson.SetBytes(data, k, exts[k])
 		if err != nil {
 			return data, err
 		}

--- a/operation_test.go
+++ b/operation_test.go
@@ -108,7 +108,7 @@ func TestOperation(t *testing.T) {
 
 func TestExtensionSorting(t *testing.T) {
 	assert := require.New(t)
-	prev := ""
+	exp := `{"x-key1":1,"x-key2":2}`
 	for n := 0; n < 100; n++ {
 		op := new(openapi.Operation)
 		op.Extensions = make(openapi.Extensions)
@@ -117,9 +117,6 @@ func TestExtensionSorting(t *testing.T) {
 
 		marshaled, _ := json.Marshal(op)
 
-		if prev != "" {
-			assert.Equal(string(marshaled), prev, strconv.Itoa(n))
-		}
-		prev = string(marshaled)
+		assert.Equal(string(marshaled), exp, strconv.Itoa(n))
 	}
 }

--- a/operation_test.go
+++ b/operation_test.go
@@ -3,6 +3,7 @@ package openapi_test
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/chanced/cmpjson"
@@ -102,5 +103,28 @@ func TestOperation(t *testing.T) {
 		}
 		assert.True(jsonpatch.Equal(data, yb), cmpjson.Diff(data, yb))
 
+	}
+}
+
+func TestExtensionSorting(t *testing.T) {
+	assert := require.New(t)
+	prev := ""
+	for n := 0; n < 100; n++ {
+		op := new(openapi.Operation)
+		op.Extensions = make(openapi.Extensions)
+		if n%2 == 0 {
+			op.Extensions.SetEncodedExtension("key2", []byte("2"))
+			op.Extensions.SetEncodedExtension("key1", []byte("1"))
+		} else {
+			op.Extensions.SetEncodedExtension("key1", []byte("1"))
+			op.Extensions.SetEncodedExtension("key2", []byte("2"))
+		}
+
+		marshaled, _ := json.Marshal(op)
+
+		if prev != "" {
+			assert.Equal(string(marshaled), prev, strconv.Itoa(n))
+		}
+		prev = string(marshaled)
 	}
 }

--- a/operation_test.go
+++ b/operation_test.go
@@ -112,13 +112,8 @@ func TestExtensionSorting(t *testing.T) {
 	for n := 0; n < 100; n++ {
 		op := new(openapi.Operation)
 		op.Extensions = make(openapi.Extensions)
-		if n%2 == 0 {
-			op.Extensions.SetEncodedExtension("key2", []byte("2"))
-			op.Extensions.SetEncodedExtension("key1", []byte("1"))
-		} else {
-			op.Extensions.SetEncodedExtension("key1", []byte("1"))
-			op.Extensions.SetEncodedExtension("key2", []byte("2"))
-		}
+		op.Extensions.SetEncodedExtension("key1", []byte("1"))
+		op.Extensions.SetEncodedExtension("key2", []byte("2"))
 
 		marshaled, _ := json.Marshal(op)
 


### PR DESCRIPTION
Having those not sorting the keys, makes difficult to diff the JSON outputs of generated OAS in up9inc/mizu.

I've reproduced the problem and looking for a fix.

In Go, JSON marshaling always sorts the keys: https://go.dev/src/encoding/json/encode.go#L796

I'd expect OAS library to conform to that.