### PR TITLE
Fixes #14 + renames ObjMapEntry to Item + fixes spelling errors

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+    push:
+        branches: ["main"]
+    pull_request:
+        branches: ["main"]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Set up Go
+              uses: actions/setup-go@v3
+              with:
+                  go-version: 1.18
+
+            - name: Build
+              run: go build -v ./...
+
+            - name: Test
+              run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # openapi - An OpenAPI 3.x library for go
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/chanced/openapi.svg)](https://pkg.go.dev/github.com/chanced/openapi)
+[![Latest Version](https://img.shields.io/github/v/tag/chanced/caps.svg?sort=semver&style=flat-square&label=version&color=blue)](https://img.shields.io/github/v/tag/chanced/caps.svg?sort=semver&style=flat-square&label=version&color=blue)
+![Build Status](https://img.shields.io/github/workflow/status/chanced/caps/Build?style=flat-square)
 
 openapi is a library for parsing and validating OpenAPI
 [3.1](https://spec.openapis.org/oas/v3.1.0),

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # openapi - An OpenAPI 3.x library for go
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/chanced/openapi.svg)](https://pkg.go.dev/github.com/chanced/openapi)
-[![Latest Version](https://img.shields.io/github/v/tag/chanced/caps.svg?sort=semver&style=flat-square&label=version&color=blue)](https://img.shields.io/github/v/tag/chanced/caps.svg?sort=semver&style=flat-square&label=version&color=blue)
-![Build Status](https://img.shields.io/github/workflow/status/chanced/caps/Build?style=flat-square)
+[![Latest Version](https://img.shields.io/github/v/tag/chanced/openapi.svg?sort=semver&style=flat-square&label=version&color=blue)](https://img.shields.io/github/v/tag/chanced/caps.svg?sort=semver&style=flat-square&label=version&color=blue)
+![Build Status](https://img.shields.io/github/workflow/status/chanced/openapi/Build?style=flat-square)
 
 openapi is a library for parsing and validating OpenAPI
 [3.1](https://spec.openapis.org/oas/v3.1.0),

--- a/anchor.go
+++ b/anchor.go
@@ -28,9 +28,33 @@ type Anchor struct {
 }
 
 type Anchors struct {
-	Standard  map[Text]Anchor // $anchor
-	Recursive *Anchor         // $recursiveAnchor
-	Dynamic   map[Text]Anchor // $dynamicAnchor
+	Standard  []Anchor // $anchor
+	Recursive *Anchor  // $recursiveAnchor
+	Dynamic   []Anchor // $dynamicAnchor
+}
+
+func (a *Anchors) StandardAnchor(name Text) *Anchor {
+	if a == nil {
+		return nil
+	}
+	for _, anchor := range a.Standard {
+		if anchor.Name == name {
+			return &anchor
+		}
+	}
+	return nil
+}
+
+func (a *Anchors) DynamicAnchor(name Text) *Anchor {
+	if a == nil {
+		return nil
+	}
+	for _, anchor := range a.Dynamic {
+		if anchor.Name == name {
+			return &anchor
+		}
+	}
+	return nil
 }
 
 func (a *Anchors) merge(b *Anchors, err error) (*Anchors, error) {
@@ -52,19 +76,9 @@ func (a *Anchors) merge(b *Anchors, err error) (*Anchors, error) {
 			Dynamic:  b.Dynamic,
 		}, nil
 	}
-	for k, bv := range b.Standard {
-		if av, ok := a.Standard[k]; ok {
-			return nil, &DuplicateAnchorError{&av, &bv}
-		}
-		a.Standard[k] = bv
-	}
-
-	for k, bv := range b.Dynamic {
-		if av, ok := a.Dynamic[k]; ok {
-			return nil, &DuplicateAnchorError{&av, &bv}
-		}
-		a.Dynamic[k] = bv
-	}
-
-	return a, nil
+	return &Anchors{
+		Standard:  append(a.Standard, b.Standard...),
+		Dynamic:   append(a.Dynamic, b.Dynamic...),
+		Recursive: a.Recursive,
+	}, nil
 }

--- a/component.go
+++ b/component.go
@@ -45,7 +45,7 @@ func (c *Component[T]) URI() *uri.URI {
 	return c.Reference.Ref
 }
 
-// MakeReference converts the Component into a refernce, altering the path of
+// MakeReference converts the Component into a reference, altering the path of
 // all nested nodes.
 func (c *Component[T]) MakeReference(ref uri.URI) error {
 	if c.Object.isNil() {

--- a/load.go
+++ b/load.go
@@ -392,8 +392,8 @@ func (l *loader) resolveRemoteRef(ctx context.Context, r refctx) (*nodectx, erro
 		return nil, NewError(fmt.Errorf("openapi: failed to resolve anchors: %w", err), r.AbsoluteLocation())
 	}
 
-	an, ok := as.Standard[a]
-	if !ok {
+	an := as.StandardAnchor(a)
+	if an == nil {
 		return nil, NewError(fmt.Errorf("openapi: ref URI not found: %s", u), r.AbsoluteLocation())
 	}
 
@@ -436,8 +436,11 @@ func (l *loader) resolveLocalRef(ctx context.Context, r refctx) (*nodectx, error
 
 	switch r.RefType() {
 	case RefTypeSchemaDynamicRef:
-		a, ok := r.root.anchors.Dynamic[Text(r.URI().Fragment)]
-		if !ok {
+		a := r.root.anchors.DynamicAnchor(Text(r.URI().Fragment))
+		if a == nil {
+			a = r.root.anchors.StandardAnchor(Text(r.URI().Fragment))
+		}
+		if a == nil {
 			return nil, NewError(fmt.Errorf("openapi: ref URI not found: %s", u), r.AbsoluteLocation())
 		}
 		err := r.resolve(a.In)
@@ -465,8 +468,8 @@ func (l *loader) resolveLocalRef(ctx context.Context, r refctx) (*nodectx, error
 			anchors:    r.root.anchors,
 		}, nil
 	case RefTypeSchema:
-		a, ok := r.root.anchors.Standard[Text(r.URI().Fragment)]
-		if !ok {
+		a := r.root.anchors.StandardAnchor(Text(r.URI().Fragment))
+		if a == nil {
 			return nil, NewError(fmt.Errorf("openapi:  not found: %s", u), r.AbsoluteLocation())
 		}
 		err := r.resolve(a.In)

--- a/node.go
+++ b/node.go
@@ -25,7 +25,7 @@ type Node interface {
 	// Kind returns the Kind for the given Node
 	Kind() Kind
 
-	// Anchors returns a list of all Anchors in the Node and all decendants.
+	// Anchors returns a list of all Anchors in the Node and all descendants.
 	Anchors() (*Anchors, error)
 
 	// Refs returns a list of all Refs from the Node and all descendants.

--- a/obj_map.go
+++ b/obj_map.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type ObjMapEntry[T node] struct {
+type Item[T node] struct {
 	Location
 	Key   Text
 	Value T
@@ -20,7 +20,7 @@ type ObjMapEntry[T node] struct {
 // ObjMap is a map of OpenAPI Objects of type T
 type ObjMap[T node] struct {
 	Location
-	Items []ObjMapEntry[T]
+	Items []Item[T]
 }
 
 func (*ObjMap[T]) Kind() Kind {
@@ -82,12 +82,12 @@ func (om *ObjMap[T]) Get(key Text) T {
 func (om *ObjMap[T]) Set(key Text, obj T) {
 	if om == nil || om.Items == nil {
 		*om = ObjMap[T]{
-			Items: []ObjMapEntry[T]{},
+			Items: []Item[T]{},
 		}
 	}
 	for i, kv := range om.Items {
 		if kv.Key == key {
-			om.Items[i] = ObjMapEntry[T]{
+			om.Items[i] = Item[T]{
 				Location: om.AppendLocation(key.String()),
 				Key:      key,
 				Value:    obj,
@@ -95,7 +95,7 @@ func (om *ObjMap[T]) Set(key Text, obj T) {
 			return
 		}
 	}
-	om.Items = append(om.Items, ObjMapEntry[T]{
+	om.Items = append(om.Items, Item[T]{
 		Location: om.AppendLocation(key.String()),
 		Key:      key,
 		Value:    obj,
@@ -123,7 +123,7 @@ func (om *ObjMap[T]) UnmarshalJSON(data []byte) error {
 		if err = json.Unmarshal([]byte(value.Raw), &pi); err != nil {
 			return false
 		}
-		m.Items = append(m.Items, ObjMapEntry[T]{Key: Text(key.String()), Value: pi})
+		m.Items = append(m.Items, Item[T]{Key: Text(key.String()), Value: pi})
 		return true
 	})
 	*om = m

--- a/schema.go
+++ b/schema.go
@@ -393,25 +393,22 @@ func (s *Schema) Anchors() (*Anchors, error) {
 	if s == nil {
 		return nil, nil
 	}
-	anchors := &Anchors{
-		Standard: make(map[text.Text]Anchor),
-		Dynamic:  make(map[text.Text]Anchor),
-	}
+	anchors := &Anchors{}
 	if s.Anchor != "" {
-		anchors.Standard[s.Anchor] = Anchor{
+		anchors.Standard = []Anchor{{
 			Location: s.Location.AppendLocation("$anchor"),
 			In:       s,
 			Name:     s.Anchor,
 			Type:     AnchorTypeRegular,
-		}
+		}}
 	}
 	if s.DynamicAnchor != "" {
-		anchors.Dynamic[s.DynamicAnchor] = Anchor{
+		anchors.Dynamic = []Anchor{{
 			Location: s.Location.AppendLocation("$dynamicAnchor"),
 			In:       s,
 			Name:     s.DynamicAnchor,
 			Type:     AnchorTypeDynamic,
-		}
+		}}
 	}
 	if s.RecursiveAnchor != nil {
 		anchors.Recursive = &Anchor{

--- a/schema_map.go
+++ b/schema_map.go
@@ -26,7 +26,7 @@ func (si *SchemaItem) Clone() SchemaItem {
 	}
 }
 
-// SchemaMap is a psuedo, ordered map ofASew3 Schemas
+// SchemaMap is a pseudo, ordered map ofASew3 Schemas
 //
 // Under the hood, SchemaMap is a slice of SchemaEntry
 type SchemaMap struct {

--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ type (
 	ServerVariableMap = ObjMap[*ServerVariable]
 )
 
-// Server represention of a Server.
+// Server representation of a Server.
 type Server struct {
 	Location   `json:"-"`
 	Extensions `json:"-"`


### PR DESCRIPTION
- Duplicate anchors no longer return an error, first found wins.
- Renames `ObjMapEntry`to `Item`
- fixes spelling errors
- Adds very simple github action for building
- Badges